### PR TITLE
Fix Netlify CMS paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+node_modules/
+dist/
+
+# Logs
+npm-debug.log*
+.yarn-debug.log*
+
+# Build output
+*.log
+
+# Editor directories and files
+.idea/
+.vscode/
+
+# Mac files
+.DS_Store
+

--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -1,0 +1,5 @@
+---
+title: "Willkommen"
+---
+
+Dies ist ein Beispielinhalt fuer die Startseite.


### PR DESCRIPTION
## Summary
- add .gitignore to keep node_modules and build output out of git
- add missing start page markdown for Netlify CMS
- ensure uploads directory exists for Netlify CMS

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6851bf032c2c832dba153442deea41e3