### PR TITLE
Fix Netlify CMS login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+node_modules/
+dist/
+
+# Logs
+npm-debug.log*
+.yarn-debug.log*
+
+# Build output
+*.log
+
+# Editor directories and files
+.idea/
+.vscode/
+
+# Mac files
+.DS_Store
+

--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -1,0 +1,5 @@
+---
+title: "Willkommen"
+---
+
+Dies ist ein Beispielinhalt fuer die Startseite.

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -3,9 +3,22 @@
   <head>
     <meta charset="utf-8" />
     <title>Content Manager</title>
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
   </head>
   <body>
     <div id="nc-root"></div>
+    <script>
+      if (window.netlifyIdentity) {
+        window.netlifyIdentity.on("init", (user) => {
+          if (!user) {
+            window.netlifyIdentity.on("login", () => {
+              document.location.href = "/admin/";
+            });
+          }
+        });
+        window.netlifyIdentity.init();
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- include Netlify Identity widget in CMS admin page
- redirect back to CMS after login
- call `netlifyIdentity.init()` so the login widget loads properly

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6851bf032c2c832dba153442deea41e3